### PR TITLE
API - Query populate

### DIFF
--- a/app/api/src/controllers/creation.controller.ts
+++ b/app/api/src/controllers/creation.controller.ts
@@ -11,7 +11,10 @@ export const queryCreations = catchAsync(async (req, res): Promise<void> => {
 });
 
 export const getCreationById = catchAsync(async (req, res): Promise<void> => {
-  const creation = await creationService.getCreationById(req.params.creation_id);
+  const creation = await creationService.getCreationById(
+    req.params.creation_id,
+    req.query.populate as string | (string | string[])[]
+  );
   res.send(creation);
 });
 

--- a/app/api/src/controllers/decision.controller.ts
+++ b/app/api/src/controllers/decision.controller.ts
@@ -3,7 +3,10 @@ import { getUserById } from '../services/user.service';
 import * as decisionService from '../services/decision.service';
 
 export const getDecisionById = catchAsync(async (req, res): Promise<void> => {
-  const decision = await decisionService.getDecisionById(req.params.decision_id);
+  const decision = await decisionService.getDecisionById(
+    req.params.decision_id,
+    req.query.populate as string | (string | string[])[]
+  );
   res.send(decision);
 });
 

--- a/app/api/src/controllers/invitation.controller.ts
+++ b/app/api/src/controllers/invitation.controller.ts
@@ -9,7 +9,10 @@ export const queryInvitations = catchAsync(async (req, res): Promise<void> => {
 });
 
 export const getInvitationById = catchAsync(async (req, res): Promise<void> => {
-  const invitation = await invitationService.getInvitationById(req.params.invite_id);
+  const invitation = await invitationService.getInvitationById(
+    req.params.invite_id,
+    req.query.populate as string | (string | string[])[]
+  );
   res.send(invitation);
 });
 

--- a/app/api/src/controllers/litigation.controller.ts
+++ b/app/api/src/controllers/litigation.controller.ts
@@ -16,7 +16,10 @@ export const queryLitigations = catchAsync(async (req, res): Promise<void> => {
 });
 
 export const getLitigationById = catchAsync(async (req, res): Promise<void> => {
-  const litigation = await litigationService.getLitigationById(req.params.litigation_id);
+  const litigation = await litigationService.getLitigationById(
+    req.params.litigation_id,
+    req.query.populate as string | (string | string[])[]
+  );
   res.send(litigation);
 });
 

--- a/app/api/src/controllers/material.controller.ts
+++ b/app/api/src/controllers/material.controller.ts
@@ -11,7 +11,10 @@ export const queryMaterials = catchAsync(async (req, res): Promise<void> => {
 });
 
 export const getMaterialById = catchAsync(async (req, res): Promise<void> => {
-  const material = await materialService.getMaterialById(req.params.material_id);
+  const material = await materialService.getMaterialById(
+    req.params.material_id,
+    req.query.populate as string | (string | string[])[]
+  );
   res.send(material);
 });
 

--- a/app/api/src/db/map.ts
+++ b/app/api/src/db/map.ts
@@ -1,0 +1,122 @@
+interface IPkMap {
+  maker_id: string;
+  invite_from: string;
+  invite_to: string;
+  author_id: string;
+  tags: string;
+  materials: string;
+  assumed_author: string;
+  winner: string;
+  issuer_id: string;
+  invitations: string;
+  decisions: string;
+  creation_id: string;
+  material_id: string;
+  invite_id: string;
+  status_id: string;
+  source_id: string;
+  type_id: string;
+  user_id: string;
+  decision_id: string;
+  tag_id: string;
+  litigation_id: string;
+}
+
+interface ITableNameMap {
+  maker_id: string;
+  invite_from: string;
+  invite_to: string;
+  author_id: string;
+  tags: string;
+  materials: string;
+  assumed_author: string;
+  winner: string;
+  issuer_id: string;
+  invitations: string;
+  decisions: string;
+  creation_id: string;
+  material_id: string;
+  invite_id: string;
+  status_id: string;
+  source_id: string;
+  type_id: string;
+  user_id: string;
+  decision_id: string;
+  tag_id: string;
+  litigation_id: string;
+}
+
+/**
+ * List of primary and foreign key names mapped to parent table primary key names
+ */
+const pkMap: IPkMap = {
+  // decision table
+  maker_id: 'user_id',
+  // invitation table
+  invite_from: 'user_id',
+  invite_to: 'user_id',
+  // material and creation table
+  author_id: 'user_id',
+  // creation table
+  tags: 'tag_id',
+  materials: 'material_id',
+  // litigation table
+  assumed_author: 'user_id',
+  winner: 'user_id',
+  issuer_id: 'user_id',
+  invitations: 'invite_id',
+  decisions: 'decision_id',
+  // common
+  creation_id: 'creation_id',
+  material_id: 'material_id',
+  invite_id: 'invite_id',
+  status_id: 'status_id',
+  source_id: 'source_id',
+  type_id: 'type_id',
+  user_id: 'user_id',
+  decision_id: 'decision_id',
+  tag_id: 'tag_id',
+  litigation_id: 'litigation_id',
+};
+
+/**
+ * List of primary key and foreign key names mapped to parent table name
+ */
+const tableNameMap: ITableNameMap = {
+  // decision table
+  maker_id: 'users',
+  // invitation table
+  invite_from: 'users',
+  invite_to: 'users',
+  // material and creation table
+  author_id: 'users',
+  // creation table
+  tags: 'tag',
+  materials: 'material',
+  // litigation table
+  assumed_author: 'users',
+  winner: 'users',
+  issuer_id: 'users',
+  invitations: 'invitation',
+  decisions: 'decision',
+  // common
+  creation_id: 'creation',
+  material_id: 'material',
+  invite_id: 'invitation',
+  status_id: 'status',
+  source_id: 'source',
+  type_id: 'material_type',
+  user_id: 'users',
+  decision_id: 'decision',
+  litigation_id: 'litigation',
+  tag_id: 'tag',
+};
+
+/**
+ * List of field names defined with array type in db tables
+ */
+const arrayFields: string[] = ['invitations', 'decisions', 'tags', 'materials'];
+
+export type { IPkMap, ITableNameMap };
+
+export { pkMap, tableNameMap, arrayFields };

--- a/app/api/src/db/plugins/populator.ts
+++ b/app/api/src/db/plugins/populator.ts
@@ -1,0 +1,64 @@
+import { IPkMap, pkMap, ITableNameMap, tableNameMap, arrayFields } from '../map';
+
+interface IPopulateField {
+  havingOriginalFieldName: string;
+  fromTable: string;
+  withPrimaryKey: string;
+  equalsForeignKey: string;
+  as: string;
+}
+
+interface IPopulator {
+  tableAlias: string;
+  fields: (string | string[])[] | undefined;
+}
+
+/**
+ * Populates the data of a forign key field from the foreign key reference table
+ * @param havingOriginalFieldName - the original field name of foreign key
+ * @param fromTable - name of table referenced by foreign key
+ * @param withPrimaryKey - name of primary key of table referenced by foreign key
+ * @param equalsForeignKey - name of foreign key
+ * @param as - name of the column returned that contains selected data
+ * @returns query string calculated by parameters
+ */
+const populateField = ({
+  havingOriginalFieldName,
+  fromTable,
+  withPrimaryKey,
+  equalsForeignKey,
+  as,
+}: IPopulateField): string => {
+  const alias = `${fromTable}_${as}_${Math.floor(Math.random() * (1000 - 1 + 1) + 1000)}`;
+
+  return arrayFields.includes(havingOriginalFieldName)
+    ? `(SELECT json_agg(${alias}.*) as ${as} FROM ${fromTable} ${alias} WHERE ${withPrimaryKey} = ANY(${equalsForeignKey})) as ${as}`
+    : `(SELECT row_to_json(${alias}.*) as ${as} FROM ${fromTable} ${alias} WHERE ${withPrimaryKey} = ${equalsForeignKey} LIMIT 1) as ${as}`;
+};
+
+/**
+ * Populates the data of forign key fields from the foreign key reference tables
+ * @param tableAlias - the alias of query table
+ * @param fields - names of foreign key fields to populate
+ * @returns query string with population queries calculated by parameters
+ */
+const populator = ({ tableAlias, fields }: IPopulator): string => {
+  return fields && fields.length > 0
+    ? `,${fields
+        .map((field) => {
+          const originalFieldName = typeof field === 'string' ? field : field[0];
+          const renamedFieldName = typeof field === 'string' ? field : field[1];
+
+          return `${populateField({
+            havingOriginalFieldName: originalFieldName,
+            fromTable: tableNameMap[originalFieldName as keyof ITableNameMap],
+            withPrimaryKey: pkMap[originalFieldName as keyof IPkMap],
+            equalsForeignKey: `${tableAlias}.${originalFieldName}`,
+            as: renamedFieldName,
+          })}`;
+        })
+        .join(',')}`
+    : '';
+};
+
+export { populator, populateField };

--- a/app/api/src/routes/v1/creation.route.ts
+++ b/app/api/src/routes/v1/creation.route.ts
@@ -195,6 +195,18 @@ export default router;
  *         schema:
  *           type: bool
  *         description: when true, returns opened creations of which all materials are recognized by co-authors (invitation accepted by co-authors)
+ *       - in: query
+ *         name: populate
+ *         schema:
+ *           type: array
+ *           items:
+ *             type: string
+ *             enum:
+ *               - source_id
+ *               - author_id
+ *               - tags
+ *               - materials
+ *         description: list of fields to populate
  *     responses:
  *       "200":
  *         description: OK
@@ -237,6 +249,18 @@ export default router;
  *         schema:
  *           type: string
  *         description: Creation id
+ *       - in: query
+ *         name: populate
+ *         schema:
+ *           type: array
+ *           items:
+ *             type: string
+ *             enum:
+ *               - source_id
+ *               - author_id
+ *               - tags
+ *               - materials
+ *         description: list of fields to populate
  *     responses:
  *       "200":
  *         description: OK

--- a/app/api/src/routes/v1/decision.route.ts
+++ b/app/api/src/routes/v1/decision.route.ts
@@ -75,6 +75,15 @@ export default router;
  *         schema:
  *           type: string
  *         description: Decision id
+ *       - in: query
+ *         name: populate
+ *         schema:
+ *           type: array
+ *           items:
+ *             type: string
+ *             enum:
+ *               - maker_id
+ *         description: list of fields to populate
  *     responses:
  *       "200":
  *         description: OK

--- a/app/api/src/routes/v1/invitation.route.ts
+++ b/app/api/src/routes/v1/invitation.route.ts
@@ -142,6 +142,17 @@ export default router;
  *         schema:
  *           type: string[]
  *         description: list of fields to order by descending
+ *       - in: query
+ *         name: populate
+ *         schema:
+ *           type: array
+ *           items:
+ *             type: string
+ *             enum:
+ *               - invite_from
+ *               - invite_to
+ *               - status_id
+ *         description: list of fields to populate
  *     responses:
  *       "200":
  *         description: OK
@@ -184,6 +195,17 @@ export default router;
  *         schema:
  *           type: string
  *         description: Invite id
+ *       - in: query
+ *         name: populate
+ *         schema:
+ *           type: array
+ *           items:
+ *             type: string
+ *             enum:
+ *               - invite_from
+ *               - invite_to
+ *               - status_id
+ *         description: list of fields to populate
  *     responses:
  *       "200":
  *         description: OK

--- a/app/api/src/routes/v1/litigation.route.ts
+++ b/app/api/src/routes/v1/litigation.route.ts
@@ -235,6 +235,21 @@ export default router;
  *         schema:
  *           type: bool
  *         description: when present, returns litigations that are to be judged by the specified user
+ *       - in: query
+ *         name: populate
+ *         schema:
+ *           type: array
+ *           items:
+ *             type: string
+ *             enum:
+ *               - creation_id
+ *               - material_id
+ *               - assumed_author
+ *               - issuer_id
+ *               - winner
+ *               - invitations
+ *               - decisions
+ *         description: list of fields to populate
  *     responses:
  *       "200":
  *         description: OK
@@ -277,6 +292,21 @@ export default router;
  *         schema:
  *           type: string
  *         description: litigation id
+ *       - in: query
+ *         name: populate
+ *         schema:
+ *           type: array
+ *           items:
+ *             type: string
+ *             enum:
+ *               - creation_id
+ *               - material_id
+ *               - assumed_author
+ *               - issuer_id
+ *               - winner
+ *               - invitations
+ *               - decisions
+ *         description: list of fields to populate
  *     responses:
  *       "200":
  *         description: OK

--- a/app/api/src/routes/v1/material.route.ts
+++ b/app/api/src/routes/v1/material.route.ts
@@ -179,6 +179,18 @@ export default router;
  *         schema:
  *           type: bool
  *         description: when true, returns materials that are claimed by original authors (in litigation process)
+ *       - in: query
+ *         name: populate
+ *         schema:
+ *           type: array
+ *           items:
+ *             type: string
+ *             enum:
+ *               - source_id
+ *               - type_id
+ *               - invite_id
+ *               - author_id
+ *         description: list of fields to populate
  *     responses:
  *       "200":
  *         description: OK
@@ -221,6 +233,18 @@ export default router;
  *         schema:
  *           type: string
  *         description: Material id
+ *       - in: query
+ *         name: populate
+ *         schema:
+ *           type: array
+ *           items:
+ *             type: string
+ *             enum:
+ *               - source_id
+ *               - type_id
+ *               - invite_id
+ *               - author_id
+ *         description: list of fields to populate
  *     responses:
  *       "200":
  *         description: OK

--- a/app/api/src/services/decision.service.ts
+++ b/app/api/src/services/decision.service.ts
@@ -1,6 +1,7 @@
 import httpStatus from 'http-status';
 import ApiError from '../utils/ApiError';
 import * as db from '../db/pool';
+import { populator } from '../db/plugins/populator';
 
 interface IDecision {
   decision_status: boolean;
@@ -35,10 +36,19 @@ export const createDecision = async (decisionBody: IDecision): Promise<IDecision
  * @param {string} id
  * @returns {Promise<IDecisionDoc|null>}
  */
-export const getDecisionById = async (id: string): Promise<IDecisionDoc | null> => {
+export const getDecisionById = async (
+  id: string,
+  populate?: string | (string | string[])[]
+): Promise<IDecisionDoc | null> => {
   const decision = await (async () => {
     try {
-      const result = await db.query(`SELECT * FROM decision WHERE decision_id = $1;`, [id]);
+      const result = await db.query(
+        `SELECT * ${populator({
+          tableAlias: 'd',
+          fields: typeof populate === 'string' ? [populate] : populate,
+        })} FROM decision d WHERE decision_id = $1;`,
+        [id]
+      );
       return result.rows[0];
     } catch {
       throw new ApiError(httpStatus.INTERNAL_SERVER_ERROR, 'internal server error');

--- a/app/api/src/validations/creation.validation.ts
+++ b/app/api/src/validations/creation.validation.ts
@@ -37,12 +37,44 @@ export const queryCreations = {
       then: Joi.forbidden(),
       otherwise: Joi.optional(),
     }),
+    populate: Joi.alternatives()
+      .try(
+        Joi.string().valid('source_id', 'author_id', 'tags', 'materials'),
+        Joi.array().items(
+          Joi.alternatives().try(
+            Joi.string().valid('source_id', 'author_id', 'tags', 'materials'),
+            Joi.array()
+              .items(Joi.string())
+              .ordered(Joi.string().valid('source_id', 'author_id', 'tags', 'materials'), Joi.string())
+              .min(2)
+              .max(2)
+          )
+        )
+      )
+      .optional(),
   }),
 };
 
 export const getCreation = {
   params: Joi.object().keys({
     creation_id: Joi.string().uuid().required(),
+  }),
+  query: Joi.object().keys({
+    populate: Joi.alternatives()
+      .try(
+        Joi.string().valid('source_id', 'author_id', 'tags', 'materials'),
+        Joi.array().items(
+          Joi.alternatives().try(
+            Joi.string().valid('source_id', 'author_id', 'tags', 'materials'),
+            Joi.array()
+              .items(Joi.string())
+              .ordered(Joi.string().valid('source_id', 'author_id', 'tags', 'materials'), Joi.string())
+              .min(2)
+              .max(2)
+          )
+        )
+      )
+      .optional(),
   }),
 };
 

--- a/app/api/src/validations/decision.validation.ts
+++ b/app/api/src/validations/decision.validation.ts
@@ -11,6 +11,19 @@ export const getDecision = {
   params: Joi.object().keys({
     decision_id: Joi.string().uuid().required(),
   }),
+  query: Joi.object().keys({
+    populate: Joi.alternatives()
+      .try(
+        Joi.string().valid('maker_id'),
+        Joi.array().items(
+          Joi.alternatives().try(
+            Joi.string().valid('maker_id'),
+            Joi.array().items(Joi.string()).ordered(Joi.string().valid('maker_id'), Joi.string()).min(2).max(2)
+          )
+        )
+      )
+      .optional(),
+  }),
 };
 
 export const updateDecision = {

--- a/app/api/src/validations/invitation.validation.ts
+++ b/app/api/src/validations/invitation.validation.ts
@@ -21,12 +21,44 @@ export const queryInvitations = {
     }),
     ascend_fields: Joi.array().items(Joi.string().valid('invite_issued')).optional(),
     descend_fields: Joi.array().items(Joi.string().valid('invite_issued')).optional(),
+    populate: Joi.alternatives()
+      .try(
+        Joi.string().valid('invite_from', 'invite_to', 'status_id'),
+        Joi.array().items(
+          Joi.alternatives().try(
+            Joi.string().valid('invite_from', 'invite_to', 'status_id'),
+            Joi.array()
+              .items(Joi.string())
+              .ordered(Joi.string().valid('invite_from', 'invite_to', 'status_id'), Joi.string())
+              .min(2)
+              .max(2)
+          )
+        )
+      )
+      .optional(),
   }),
 };
 
 export const getInvitation = {
   params: Joi.object().keys({
     invite_id: Joi.string().uuid().required(),
+  }),
+  query: Joi.object().keys({
+    populate: Joi.alternatives()
+      .try(
+        Joi.string().valid('invite_from', 'invite_to', 'status_id'),
+        Joi.array().items(
+          Joi.alternatives().try(
+            Joi.string().valid('invite_from', 'invite_to', 'status_id'),
+            Joi.array()
+              .items(Joi.string())
+              .ordered(Joi.string().valid('invite_from', 'invite_to', 'status_id'), Joi.string())
+              .min(2)
+              .max(2)
+          )
+        )
+      )
+      .optional(),
   }),
 };
 

--- a/app/api/src/validations/litigation.validation.ts
+++ b/app/api/src/validations/litigation.validation.ts
@@ -29,12 +29,98 @@ export const queryLitigations = {
     ascend_fields: Joi.array().items(Joi.string().valid('litigation_start', 'litigation_end')).optional(),
     descend_fields: Joi.array().items(Joi.string().valid('litigation_start', 'litigation_end')).optional(),
     judged_by: Joi.string().uuid().optional(),
+    populate: Joi.alternatives()
+      .try(
+        Joi.string().valid(
+          'creation_id',
+          'material_id',
+          'assumed_author',
+          'issuer_id',
+          'winner',
+          'invitations',
+          'decisions'
+        ),
+        Joi.array().items(
+          Joi.alternatives().try(
+            Joi.string().valid(
+              'creation_id',
+              'material_id',
+              'assumed_author',
+              'issuer_id',
+              'winner',
+              'invitations',
+              'decisions'
+            ),
+            Joi.array()
+              .items(Joi.string())
+              .ordered(
+                Joi.string().valid(
+                  'creation_id',
+                  'material_id',
+                  'assumed_author',
+                  'issuer_id',
+                  'winner',
+                  'invitations',
+                  'decisions'
+                ),
+                Joi.string()
+              )
+              .min(2)
+              .max(2)
+          )
+        )
+      )
+      .optional(),
   }),
 };
 
 export const getLitigation = {
   params: Joi.object().keys({
     litigation_id: Joi.string().uuid().required(),
+  }),
+  query: Joi.object().keys({
+    populate: Joi.alternatives()
+      .try(
+        Joi.string().valid(
+          'creation_id',
+          'material_id',
+          'assumed_author',
+          'issuer_id',
+          'winner',
+          'invitations',
+          'decisions'
+        ),
+        Joi.array().items(
+          Joi.alternatives().try(
+            Joi.string().valid(
+              'creation_id',
+              'material_id',
+              'assumed_author',
+              'issuer_id',
+              'winner',
+              'invitations',
+              'decisions'
+            ),
+            Joi.array()
+              .items(Joi.string())
+              .ordered(
+                Joi.string().valid(
+                  'creation_id',
+                  'material_id',
+                  'assumed_author',
+                  'issuer_id',
+                  'winner',
+                  'invitations',
+                  'decisions'
+                ),
+                Joi.string()
+              )
+              .min(2)
+              .max(2)
+          )
+        )
+      )
+      .optional(),
   }),
 };
 

--- a/app/api/src/validations/material.validation.ts
+++ b/app/api/src/validations/material.validation.ts
@@ -25,12 +25,44 @@ export const queryMaterials = {
     }),
     is_recognized: Joi.bool().optional(),
     is_claimed: Joi.bool().optional(),
+    populate: Joi.alternatives()
+      .try(
+        Joi.string().valid('source_id', 'type_id', 'invite_id', 'author_id'),
+        Joi.array().items(
+          Joi.alternatives().try(
+            Joi.string().valid('source_id', 'type_id', 'invite_id', 'author_id'),
+            Joi.array()
+              .items(Joi.string())
+              .ordered(Joi.string().valid('source_id', 'type_id', 'invite_id', 'author_id'), Joi.string())
+              .min(2)
+              .max(2)
+          )
+        )
+      )
+      .optional(),
   }),
 };
 
 export const getMaterial = {
   params: Joi.object().keys({
     material_id: Joi.string().uuid().required(),
+  }),
+  query: Joi.object().keys({
+    populate: Joi.alternatives()
+      .try(
+        Joi.string().valid('source_id', 'type_id', 'invite_id', 'author_id'),
+        Joi.array().items(
+          Joi.alternatives().try(
+            Joi.string().valid('source_id', 'type_id', 'invite_id', 'author_id'),
+            Joi.array()
+              .items(Joi.string())
+              .ordered(Joi.string().valid('source_id', 'type_id', 'invite_id', 'author_id'), Joi.string())
+              .min(2)
+              .max(2)
+          )
+        )
+      )
+      .optional(),
   }),
 };
 


### PR DESCRIPTION
Previously we had to query data of an entity with-in another entity separately. 

Something like, lets say `https://pocre-api.herokuapp.com/v1/decision/33a1a7d0-1616-48ae-99a0-f8f887a82874`, which will give us this response

![Screenshot 2022-10-30 at 4 42 09 AM](https://user-images.githubusercontent.com/68777211/198856436-af2da396-98ab-48fa-8731-5f21af8151b8.png)

And to get the details of maker (**maker_id**) we had to make a separate request to `https://pocre-api.herokuapp.com/v1/users/43704731-d816-4f1f-a599-eb290f67c3f4` which gave us the detailed data of **maker**

![Screenshot 2022-10-30 at 4 43 31 AM](https://user-images.githubusercontent.com/68777211/198856481-13853521-12dc-4b15-85fc-53b8777101b3.png)

## What this (query populate) feature brings
Now we can get the data of **maker** from the decision endpoints with a single api call by adding some query params
`https://pocre-api.herokuapp.com/v1/decision/33a1a7d0-1616-48ae-99a0-f8f887a82874?populate[]=maker_id`. Notice the **?populate[]=maker_id** at the end of url. This will give us the populated results from the decision.

This works for all **GET** endpoint to resources that have a foreign key references (from which they can populate data). It also populates both **object** and **array** fields.  

The is the list of endpoints and their docs that are now supporting this feature
1. https://pocre-api.herokuapp.com/v1/docs/#/Creation/get_creations (`/v1/creations/`)
2. https://pocre-api.herokuapp.com/v1/docs/#/Creation/get_creations__creation_id_ (`/v1/creations/{creation_id}`)
3. https://pocre-api.herokuapp.com/v1/docs/#/Decision/get_decision__decision_id_ (`/v1/decision/{decision_id}`)
4. https://pocre-api.herokuapp.com/v1/docs/#/Invitation/get_invitations (`/v1/invitations/{invitation_id}`)
5. https://pocre-api.herokuapp.com/v1/docs/#/Invitation/get_invitations__invite_id_ (`/v1/invitations/{invitation_id}`)
6. https://pocre-api.herokuapp.com/v1/docs/#/Litigation/get_litigations (`/v1/litigations/{litigation_id}`)
7. https://pocre-api.herokuapp.com/v1/docs/#/Litigation/get_litigations__litigation_id_ (`/v1/litigations/{litigation_id}`)
8. https://pocre-api.herokuapp.com/v1/docs/#/Material/get_materials (`/v1/materials/{material_id}`)
9. https://pocre-api.herokuapp.com/v1/docs/#/Material/get_materials__material_id_ (`/v1/materials/{material_id}`)

Now we can also refactor our frontend app to use these features, which will improve performance and maintainability

### Renaming populated fields returned from response

**Important:** The populate feature only works at the first level like `litigation.creation_id`, currently we cannot do `litigation.creation_id.materials.invite_id.invite_from` or any deep nested population.