### PR TITLE
API - Added nested db populator

### DIFF
--- a/app/api/src/db/plugins/populatorNested.ts
+++ b/app/api/src/db/plugins/populatorNested.ts
@@ -1,0 +1,150 @@
+import { IPkMap, pkMap, ITableNameMap, tableNameMap, arrayFields } from '../map';
+
+interface IPopulator {
+  tableAlias: string;
+  fields: string[];
+}
+
+interface IDeepPopulate {
+  fieldName: string;
+  withPopulated?: (IDeepPopulate | string)[];
+}
+
+interface IDeepFieldPopulator extends IDeepPopulate {
+  selectAs: string;
+  tableAlias: string;
+}
+
+/**
+ * Populates the data of a forign key field from the foreign key reference table with recursion
+ * @param tableAlias - alias of table referenced by foreign key
+ * @param selectAs - name of the column returned that contains selected data
+ * @param fieldName - the original field name of foreign key
+ * @param withPopulated - fields to deep populate by fieldName and withPopulated fields
+ * @returns query string calculated by parameters
+ */
+const deepFieldPopulator = ({ tableAlias, selectAs, fieldName, withPopulated }: IDeepFieldPopulator): string => {
+  // calculated fields
+  const selectAsArray = arrayFields.includes(fieldName);
+  const fromTable = tableNameMap[fieldName as keyof ITableNameMap];
+  const withPrimaryKey = pkMap[fieldName as keyof IPkMap];
+  const alias = `${fromTable}_${selectAs}_${Math.floor(Math.random() * (100000 - 1 + 1) + 100000)}`;
+  const equalsForeignKey = `${tableAlias}.${fieldName}`;
+
+  // base case
+  if (!withPopulated) {
+    return selectAsArray
+      ? `(SELECT json_agg(${alias}.*) as ${selectAs} FROM ${fromTable} ${alias} WHERE ${withPrimaryKey} = ANY(${equalsForeignKey})) as ${selectAs}`
+      : `(SELECT row_to_json(${alias}.*) as ${selectAs} FROM ${fromTable} ${alias} WHERE ${withPrimaryKey} = ${equalsForeignKey} LIMIT 1) as ${selectAs}`;
+  }
+
+  // second level recurse
+  const rescursivelyPopulated = withPopulated
+    .map((x) =>
+      deepFieldPopulator({
+        tableAlias: alias,
+        ...(typeof x === 'string'
+          ? {
+              fieldName: x,
+              selectAs: x,
+            }
+          : {
+              fieldName: x.fieldName,
+              selectAs: x.fieldName,
+              withPopulated: x.withPopulated,
+            }),
+      })
+    )
+    .join(',');
+
+  // first level conditions
+  const conditions = `${fromTable} ${alias} WHERE ${withPrimaryKey} = ${
+    selectAsArray ? `ANY(${equalsForeignKey})` : equalsForeignKey
+  }`;
+
+  // first level recurse
+  return selectAsArray
+    ? `(SELECT json_agg(${alias}.*) as ${selectAs} FROM 
+          (SELECT *, ${rescursivelyPopulated} FROM ${conditions}) 
+          as ${alias}
+        ) as ${selectAs}`
+    : `(SELECT row_to_json(${alias}.*) as ${selectAs} FROM
+          (SELECT *, ${rescursivelyPopulated} FROM ${conditions}) 
+          as ${alias}
+        ) as ${selectAs}`;
+};
+
+function makeHierarchyTree(obj: any) {
+  const result: any = {};
+
+  // For each object path (property key) in the object
+  // eslint-disable-next-line no-restricted-syntax, guard-for-in
+  for (const objectPath in obj) {
+    // Split path into component parts
+    const parts = objectPath.split('.');
+
+    // Create sub-objects along path as needed
+    let target = result;
+    while (parts.length > 1) {
+      const part = parts.shift();
+      // eslint-disable-next-line no-multi-assign
+      target = target[part as string] = target[part as string] || {};
+    }
+
+    // Set value at end of path
+    target[parts[0]] = obj[objectPath];
+  }
+
+  return result;
+}
+
+const transformObjectToPopulator = (obj: any = {}): any => {
+  return Object.keys(obj).map((x) => ({
+    fieldName: x,
+    selectAs: x,
+    ...(Object.keys(obj[x]).length > 0 && {
+      withPopulated: Object.keys(obj[x]).map((y) =>
+        Object.values(obj[x][y]).length > 0 ? transformObjectToPopulator({ [y]: obj[x][y] })[0] : y
+      ),
+    }),
+  }));
+};
+
+const fieldPopulateObjectsGenerator = (fields: string[]) => {
+  const sortedFields = [...fields].sort((a, b) => a.length - b.length);
+
+  const fieldsToObject: any = {};
+  sortedFields.map((x) => {
+    fieldsToObject[x as any] = {};
+    return null;
+  });
+
+  const objectTree = makeHierarchyTree(fieldsToObject);
+
+  const populatorObjects = Object.keys(objectTree).map((x) => transformObjectToPopulator({ [x]: objectTree[x] })[0]);
+
+  return populatorObjects;
+};
+
+/**
+ * Populates the data of forign key fields from the foreign key reference tables
+ * @param tableAlias - the alias of query table
+ * @param fields - names of foreign key fields to populate
+ * @returns query string with population queries calculated by parameters
+ */
+const populator = ({ tableAlias, fields }: IPopulator): string => {
+  if (fields.length === 0) return '';
+
+  const fieldsPopulateObjects = fieldPopulateObjectsGenerator(fields);
+
+  return `,${fieldsPopulateObjects
+    .map((populateObject) => {
+      return `${deepFieldPopulator({
+        tableAlias,
+        ...populateObject,
+      })}`;
+    })
+    .join(',')}`;
+};
+
+export { populator, deepFieldPopulator };


### PR DESCRIPTION
### This is a big part of the db query populate plugin feature we did already

## Deep Query Populate
This change basically allows us to query deeply nested records by building complex queries with recursive and same level data population formatted as a json object or array. 

**For example**, lets say this is a litigation record stored in db
```json
{
    "litigation_id": "e779edd8-2288-4163-8ffc-48fadab6b706",
    "litigation_title": "kcdjbcdbj",
    "litigation_description": "jbcdjvjhvd",
    "creation_id": "843a752a-cff2-4d6f-bcac-7b5381802831",
    "material_id": "fef2ab9d-2894-423f-90c3-0b4b89d99a22",
    "assumed_author": "f8665338-f0ac-42c0-a5bb-e6a4bebbc55e",
    "issuer_id": "716fb913-2e96-4f47-9d4e-a825476f3c7f",
    "winner": "f8665338-f0ac-42c0-a5bb-e6a4bebbc55e",
    "invitations": [
        "c5453072-c2c0-49c6-82c1-511c6797ddf6",
        "a5a6963c-60a9-411a-853c-3a51dabee7db",
        "8ee5fcf9-e6f1-4b69-a8dd-0f10fce1d1cc",
        "5b8dfa37-c3ec-4156-8d8b-c5e82647546a",
        "44faf734-69a1-4299-b4db-11a96e1de4a9"
    ],
    "decisions": [
        "ff5d02c0-07a3-4168-be96-b77eea76a88c",
        "725d0f9b-edd4-4472-90ad-5238537426c2"
    ],
    "litigation_start": "2022-10-19T00:00:00.000Z",
    "litigation_end": "2022-11-05T00:00:00.000Z",
    "reconcilate": false,
    "ownership_transferred": null
}
```
Now, let's say we want to deep populate all the foreign key links in the creation linked to this litigation. We can do that with the new change by passing these query values
```
'creation_id',
'creation_id.source_id',
'creation_id.author_id',
'creation_id.tags',
'creation_id.materials.source_id',
'creation_id.materials.author_id',
'creation_id.materials.type_id',
'creation_id.materials.invite_id.invite_to',
'creation_id.materials.invite_id.invite_from',
'creation_id.materials.invite_id.status_id',
``` 
which will populate all the records deeply inside the creation_id linked to this litigation with a single api call. This is the resultant object
```json
{
    "litigation_id": "e779edd8-2288-4163-8ffc-48fadab6b706",
    "litigation_title": "kcdjbcdbj",
    "litigation_description": "jbcdjvjhvd",
    "creation_id": {
        "creation_id": "843a752a-cff2-4d6f-bcac-7b5381802831",
        "creation_title": "mario test preview",
        "creation_description": "this is a basic test",
        "source_id": {
            "source_id": "185faf81-23a3-4eee-bea6-142211028b7d",
            "source_title": "mario test preview",
            "source_description": "this is a basic test",
            "site_url": "https://pocre.netlify.app/creations/create"
        },
        "author_id": {
            "user_id": "b92cafe4-fdc3-4c6b-aac6-9182de363a0c",
            "user_name": "Armand Kiehn",
            "wallet_address": "57001731decc414d86b27ec2f7844eab8a41a2306173437a8ada964b96c864949c298761fdfd41b1b6a7e33fd3a9a13373adebcda26448799fd5ddbd17c06ce5",
            "user_bio": null,
            "date_joined": "2022-09-28",
            "image_url": null,
            "email_address": "arman.kiehn@gmail.com",
            "phone": null,
            "verified_id": "28y9gd27g2g237g80hnibhi",
            "reputation_stars": 1
        },
        "tags": [
            {
                "tag_id": "388f476d-8d27-4e59-ae88-3dc39d3cc4d4",
                "tag_name": "too big",
                "tag_description": null,
                "tag_created": "2022-10-24"
            }
        ],
        "materials": [
            {
                "material_id": "fef2ab9d-2894-423f-90c3-0b4b89d99a22",
                "material_title": "test",
                "material_description": null,
                "material_link": "https://github.com/e-Learning-DAO/POCRE/projects/1",
                "source_id": {
                    "source_id": "4700108b-0eed-4425-a44f-8a0436e0c759",
                    "source_title": "test",
                    "source_description": null,
                    "site_url": "https://pocre.netlify.app/creations/create"
                },
                "type_id": {
                    "type_id": "813b40b4-b5f5-410d-b760-f350b7289a46",
                    "type_name": "image",
                    "type_description": "test"
                },
                "invite_id": {
                    "invite_id": "5d9422b1-4766-4d8a-b895-05f5ab4e3bea",
                    "invite_from": {
                        "user_id": "b92cafe4-fdc3-4c6b-aac6-9182de363a0c",
                        "user_name": "Armand Kiehn",
                        "wallet_address": "57001731decc414d86b27ec2f7844eab8a41a2306173437a8ada964b96c864949c298761fdfd41b1b6a7e33fd3a9a13373adebcda26448799fd5ddbd17c06ce5",
                        "user_bio": null,
                        "date_joined": "2022-09-28",
                        "image_url": null,
                        "email_address": "arman.kiehn@gmail.com",
                        "phone": null,
                        "verified_id": "28y9gd27g2g237g80hnibhi",
                        "reputation_stars": 1
                    },
                    "invite_to": {
                        "user_id": "f8665338-f0ac-42c0-a5bb-e6a4bebbc55e",
                        "user_name": "mario",
                        "wallet_address": null,
                        "user_bio": null,
                        "date_joined": "2022-10-24",
                        "image_url": null,
                        "email_address": null,
                        "phone": null,
                        "verified_id": null,
                        "reputation_stars": null
                    },
                    "invite_description": null,
                    "invite_issued": "2022-10-24",
                    "status_id": {
                        "status_id": "44347ee9-9049-471e-abd0-b5706f959a6a",
                        "status_name": "pending",
                        "status_description": null,
                        "action_made": "2022-10-24"
                    }
                },
                "author_id": {
                    "user_id": "f8665338-f0ac-42c0-a5bb-e6a4bebbc55e",
                    "user_name": "mario",
                    "wallet_address": null,
                    "user_bio": null,
                    "date_joined": "2022-10-24",
                    "image_url": null,
                    "email_address": null,
                    "phone": null,
                    "verified_id": null,
                    "reputation_stars": null
                },
                "is_claimable": false
            }
        ],
        "creation_date": "2022-10-24",
        "is_draft": false,
        "is_claimable": true
    },
    "material_id": "fef2ab9d-2894-423f-90c3-0b4b89d99a22",
    "assumed_author": "f8665338-f0ac-42c0-a5bb-e6a4bebbc55e",
    "issuer_id": "716fb913-2e96-4f47-9d4e-a825476f3c7f",
    "winner": "f8665338-f0ac-42c0-a5bb-e6a4bebbc55e",
    "invitations": [
        "c5453072-c2c0-49c6-82c1-511c6797ddf6",
        "a5a6963c-60a9-411a-853c-3a51dabee7db",
        "8ee5fcf9-e6f1-4b69-a8dd-0f10fce1d1cc",
        "5b8dfa37-c3ec-4156-8d8b-c5e82647546a",
        "44faf734-69a1-4299-b4db-11a96e1de4a9"
    ],
    "decisions": [
        "ff5d02c0-07a3-4168-be96-b77eea76a88c",
        "725d0f9b-edd4-4472-90ad-5238537426c2"
    ],
    "litigation_start": "2022-10-18T19:00:00.000Z",
    "litigation_end": "2022-11-04T19:00:00.000Z",
    "reconcilate": false,
    "ownership_transferred": null
}
```

We can further expand this and also add 
```

'material_id.author_id',
'material_id.source_id',
'material_id.type_id',
'material_id.invite_id.invite_to',
'material_id.invite_id.invite_from',
'material_id.invite_id.status_id',
'assumed_author',
'issuer_id',
'winner',
'decisions',
'invitations',
'invitations.invite_from',
'invitations.invite_to',
'invitations.status_id',
'decisions.maker_id',
```

with our original query which will also deeply populate these fields also with the ones above. I will not mention here because that response object is more than 400 lines long. But the big thing is that we don't have to write those deep nesting queries. The plugin we wrote takes care of it all.

### Expected changes (Renaming deep populated fields)
This expected change will allow use to renamed deeply populated fields
