### PR TITLE
API - Return found user if exists when creating new user

### DIFF
--- a/app/api/src/controllers/user.controller.ts
+++ b/app/api/src/controllers/user.controller.ts
@@ -14,8 +14,14 @@ export const getUserById = catchAsync(async (req, res): Promise<void> => {
   res.send(user);
 });
 
-export const createUser = catchAsync(async (req, res): Promise<void> => {
+export const createUser = catchAsync(async (req, res): Promise<any> => {
   const hashedWalletAddress = encrypt(req.body.wallet_address);
+
+  // check if this user already exists
+  const foundUser = await userService.getUserByWalletAddress(hashedWalletAddress).catch(() => null);
+  if (foundUser) return res.send(foundUser);
+
+  // create user
   const newUser = await userService.createUser({
     ...req.body,
     user_name: req.body.user_name || 'anonymous',


### PR DESCRIPTION
The api was giving internal server error when creating a user with a wallet address that already exists. Not a major problem but to have a decent workflow, The 2 choices to tackle this were to either
- Give an error that a user already exists with this wallet address
- Return the user that has this wallet address (this is the one implemented)