### PR TITLE
WEB - Allow a user to own a material during creation process

### DIFF
--- a/app/web-frontend/src/pages/Creations/common/form/Steps/Two.jsx
+++ b/app/web-frontend/src/pages/Creations/common/form/Steps/Two.jsx
@@ -9,6 +9,7 @@ import Input from 'components/uicore/Input';
 import Select from 'components/uicore/Select';
 import TagInput from 'components/uicore/TagInput';
 import { useState } from 'react';
+import authUser from 'utils/helpers/authUser';
 import { stepTwoAuthorInviteValidation, stepTwoMaterialValidation } from './validation';
 
 function NewMaterial({
@@ -317,6 +318,7 @@ export default function StepTwo({
   authorSuggestions = [],
   onAuthorInputChange = () => {},
 }) {
+  const user = authUser.getUser();
   const [formKey, setFormKey] = useState(new Date().toISOString());
   const [materials, setMaterials] = useState(initialMaterials);
   const [showInviteAuthorDialog, setShowInviteAuthorDialog] = useState(false);
@@ -428,7 +430,7 @@ export default function StepTwo({
                 onInput={onAuthorInputChange}
                 selectedTags={invitedAuthor ? [invitedAuthor] : []}
                 placeholder="Type author name and select from suggestions below"
-                tagSuggestions={authorSuggestions.map((x) => x.user_name) || []}
+                tagSuggestions={authorSuggestions.map((x) => (`${x.user_name}${user.user_id === x?.user_id ? ' (You)' : ''}`)) || []}
               />
               <Button className="inviteButton" style={{ width: 'fit-content', paddingLeft: '24px', paddingRight: '24px' }} onClick={() => setShowInviteAuthorDialog(true)}>
                 <img width={17} style={{ marginRight: '10px' }} alt="invite-icon" src={InviteIcon} />

--- a/app/web-frontend/src/pages/Creations/common/form/useCreationForm.jsx
+++ b/app/web-frontend/src/pages/Creations/common/form/useCreationForm.jsx
@@ -66,6 +66,12 @@ const makeCommonResource = async (
           return temporaryAuthor;
         }
 
+        // check if its the creation author trying to own material
+        const user = authUser.getUser();
+        if (authorName === `${user?.user_name} (You)`) {
+          return user;
+        }
+
         // return if author found from suggestions
         temporaryAuthor = authorSuggestions.find(
           (suggestion) => suggestion.user_name.trim() === authorName,
@@ -100,9 +106,6 @@ const makeCommonResource = async (
   return { tags, materials };
 };
 
-// get auth user
-const user = authUser.getUser();
-
 const useCreationForm = ({
   onCreationFetch = () => {},
 }) => {
@@ -127,7 +130,6 @@ const useCreationForm = ({
     handleSuggestionInputChange: handleAuthorInputChange,
   } = useSuggestions({
     search: 'users',
-    filterSuggestion: user?.user_name?.trim(),
   });
 
   // get creation details


### PR DESCRIPTION
**Ticket/s:** https://github.com/e-Learning-DAO/POCRE/issues/221
**Desc:** Implements the ownership of material by a creation author during the creation process
**Visuals:**
During the creation step 2 a user can search for themselves and select them as the material author. Its indicated by `{{username}} (You)`, the label '(You)' is added after the auth user's name

![Screenshot 2022-12-23 at 1 22 19 AM](https://user-images.githubusercontent.com/68777211/209220115-89317946-350c-4e9c-9fac-ed7af26e3dab.png)
![Screenshot 2022-12-23 at 1 22 10 AM](https://user-images.githubusercontent.com/68777211/209220121-83450d09-ad3f-41f4-a62e-8b5d4cd7bb2c.png)




