### PR TITLE
WEB - fixed slider on home page

### DIFF
--- a/app/web-frontend/src/pages/Home/index.jsx
+++ b/app/web-frontend/src/pages/Home/index.jsx
@@ -64,7 +64,7 @@ function Home() {
         )}
       {
         isSliderImagesFetched ? <Loader /> : (
-          sliderImages && (
+          sliderImages && getSliderImages(sliderImages).length > 0 && (
             <Slider
               handleSlideClick={handleSlideClick}
               slideImageList={getSliderImages(sliderImages)}


### PR DESCRIPTION
**Desc:** We had some issues on the home page after clearing the db (due to stale data). After that the home page was not showing up (just a blank white screen). The issue had roots in the media format validation, we already have a ticket for that https://github.com/eLearningDAO/POCRE/issues/175. 

In this PR, the white page issue is fixed and now we see the slider. If there are correct media formats set in db, then the slider will render correct images. If there are no images the slider will not be rendered

Previously we were checking the media type on frontend for home page here https://github.com/eLearningDAO/POCRE/blob/801dea4b7af75ec53786211ebdb7ba4e33c37100/app/web-frontend/src/pages/Home/index.jsx#L17

But since it will eventually be moved to api, this check has been removed for the home page to work correctly.