### PR TITLE
WEB- Fixed media rendering on litigation details page for creations

### DIFF
--- a/app/web-frontend/src/pages/Litigations/Details/index.jsx
+++ b/app/web-frontend/src/pages/Litigations/Details/index.jsx
@@ -14,6 +14,7 @@ import UserCard from 'components/cards/UserCard';
 import Loader from 'components/uicore/Loader';
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import statusTypes from 'utils/constants/statusTypes';
 import './index.css';
 import useDetails from './useDetails';
 
@@ -129,7 +130,7 @@ export default function LitigationDetails() {
       <Grid display="flex" marginTop="36px" width="100%">
         <MaterialCard
           mediaUrl={litigation?.material?.material_link || litigation?.creation?.creation_link}
-          mediaType={litigation?.material?.material_link || litigation?.creation?.creation_type}
+          mediaType={litigation?.material?.material_type || litigation?.creation?.creation_type}
           link={litigation?.material?.material_link || litigation?.creation?.creation_link}
           title={litigation?.material?.material_title || litigation?.creation?.creation_title}
           description={litigation?.material?.material_description
@@ -141,7 +142,7 @@ export default function LitigationDetails() {
           recognitionStatus={
             litigation?.material && litigation?.material?.recognition?.status?.status_name
               ? litigation?.material?.recognition?.status?.status_name
-              : null
+              : statusTypes.ACCEPTED
           }
         />
       </Grid>

--- a/app/web-frontend/src/pages/Litigations/Details/useDetails.jsx
+++ b/app/web-frontend/src/pages/Litigations/Details/useDetails.jsx
@@ -27,7 +27,7 @@ const useDetails = () => {
     queryKey: [`litigation-${litigationId}`],
     queryFn: async () => {
       // get litigation details
-      const toPopulate = ['issuer_id', 'assumed_author', 'winner', 'decisions', 'recognitions', 'recognitions.recognition_for', 'material_id'];
+      const toPopulate = ['issuer_id', 'assumed_author', 'winner', 'decisions', 'recognitions', 'recognitions.recognition_for', 'creation_id', 'material_id'];
       const litigationResponse = await Litigation.getById(litigationId, toPopulate.map((x) => `populate=${x}`).join('&'));
 
       // calculate litigation status

--- a/app/web-frontend/src/utils/constants/statusTypes.js
+++ b/app/web-frontend/src/utils/constants/statusTypes.js
@@ -3,4 +3,5 @@ export default Object.freeze({
   WITHDRAWN: 'withdrawn',
   STARTED: 'started',
   CLOSED: 'closed',
+  ACCEPTED: 'accepted',
 });


### PR DESCRIPTION
**Ticket/s:**
https://github.com/eLearningDAO/POCRE/issues/188

**Desc:**
Fixes the incorrect or something no rendering of creations on the litigation details page. Empty media blocks like these dont show up now

![image](https://user-images.githubusercontent.com/68777211/210424525-fd6dd1f6-5141-46f4-9c5a-48432426eb89.png)


**Additional Context:**
This issue was fixed for the materials display in #234. But the creations display still had this issue on the litigation details page.