### PR TITLE
Fixed closed and pending litigations not showing

### DIFF
--- a/app/web-frontend/src/pages/Litigations/Home/useHome.jsx
+++ b/app/web-frontend/src/pages/Litigations/Home/useHome.jsx
@@ -60,7 +60,10 @@ const useHome = () => {
         closed: litigationResponse?.results?.filter(
           (x) => (
             moment(x.litigation_end).isBefore(isoDateToday)
-            && x.litigation_status === statusTypes.STARTED
+            // NOTE: [TEMP FIX]
+            // if the original author does not do something in reconcilation phase then
+            // the litigations status is pending
+            // && x.litigation_status === statusTypes.STARTED
           )
             || x.litigation_status === statusTypes.WITHDRAWN,
         ),


### PR DESCRIPTION
### Background
There is a scenario in which the original author of the litigated item will not respond, in this case the litigation status is `pending`. 

### Bug
f the litigation passes the closing date and the original author did not respond, then the litigation will not show up in the closed litigation tab. This PR fixes this bug.

This bug is not documented as a ticket since we plan to change how the original author responds and how start/end dates work in https://github.com/eLearningDAO/POCRE/issues/280.