### PR TITLE
[HOTFIX] Dont require creation id in litigation update req

### DIFF
--- a/app/api/src/validations/litigation.validation.ts
+++ b/app/api/src/validations/litigation.validation.ts
@@ -52,7 +52,7 @@ export const updateLitigation = {
     .keys({
       litigation_title: Joi.string().optional(),
       litigation_description: Joi.string().optional().allow('').allow(null),
-      creation_id: Joi.string().uuid().required(),
+      creation_id: Joi.string().uuid().optional(), // [HOTFIX]: this is required if creation in draft
       material_id: Joi.string().uuid().optional(),
       decisions: Joi.array().items(Joi.string().uuid()).unique().optional(),
       assumed_author_response: Joi.string()


### PR DESCRIPTION
A proper fix is to separate requests by context but for now this change will fix the issue in https://github.com/eLearningDAO/POCRE/issues/324